### PR TITLE
Non-interactive Matplotlib for tests

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -1,7 +1,10 @@
 """Configuration for the pytest tests."""
 
 import pytest
+import matplotlib
 
+
+matplotlib.use('Agg')  # Use non-interactive backend to prevent loss of focus during test.
 
 collect_ignore = ['envs/', 'venv/', 'data/', 'logs/']
 


### PR DESCRIPTION
Set matplotlib to use a non-interactive backend for tests so that IDE focus is not lost during test